### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ To contribute to this project, please follow these steps:
 ### 1. Clone and Fork the Repository
 First, clone the repository using the following command:
 ```bash
-git clone https://github.com/pytorch-labs/leanrl.git
+git clone https://github.com/meta-pytorch/leanrl.git
 ```
 
 Then, fork the repository by clicking the "Fork" button on the top-right corner of the GitHub page. 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Unlike CleanRL, LeanRL does not currently support `poetry`.
 Prerequisites:
 * Clone the repo locally:
   ```bash
-  git clone https://github.com/pytorch-labs/leanrl.git && cd leanrl
+  git clone https://github.com/meta-pytorch/leanrl.git && cd leanrl
   ```
 - `pip install -r requirements/requirements.txt` for basic requirements, or another `.txt` file for specific applications.
 


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:26:15.153843+00:00Z